### PR TITLE
call Dimension on initial and terminal object in example

### DIFF
--- a/examples/doc/KxyClosed.g
+++ b/examples/doc/KxyClosed.g
@@ -19,6 +19,10 @@ D := ClosedSubsetOfSpec( HomalgMatrix( "[ x^2*y^3*(x-y) ]", 1, 1, R ) );
 #! V_{Q[x,y]}( <...> )
 T := TerminalObject( ZC );
 #! V_{Q[x,y]}( <...> )
+Dimension( T );
+#! 2
 I := InitialObject( ZC );
 #! V_{Q[x,y]}( <...> )
+Dimension( I );
+#! -1
 #! @EndExample


### PR DESCRIPTION
The main point is to illustrate that `-1` is returned as the dimension of the empty set (initial object). The dimension of the terminal object is included for completeness.