### PR TITLE
add \DeclareUnicodeCharacter{2205}{\O}

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -10,7 +10,8 @@ fi;
 AutoDoc( 
         rec(
             scaffold := rec( gapdoc_latex_options := rec( 
-                             LateExtraPreamble := "\\usepackage{amsmath}\\usepackage[T1]{fontenc}\n\\usepackage{tikz}\n\\usetikzlibrary{shapes,arrows,matrix}\n\\usepackage{faktor}" 
+                             LateExtraPreamble := "\\usepackage{amsmath}\\usepackage[T1]{fontenc}\n\\usepackage{tikz}\n\\usetikzlibrary{shapes,arrows,matrix}\n\\usepackage{faktor}\n\\DeclareUnicodeCharacter{2205}{\\O}\n" 
+
                                                         ),
                              entities := [ "GAP4", "CAP", "homalg" ],
                              ),


### PR DESCRIPTION
With this addition the PDF documentation can again be created successfully. The regression was caused by pull request #1.