### PR TITLE
"+" -> "∪" in examples/Example.g; declare ∪ and ⋃

### DIFF
--- a/examples/Example.g
+++ b/examples/Example.g
@@ -60,9 +60,9 @@ tp := d * xuy;
 Dimension( tp );
 #! 0
 c := lc + tp;
-#! ( V_{Q[x,y]}( I1 ) \ V_{Q[x,y]}( J1 ) ) + ( V_{Q[x,y]}( I2 ) \ V_{Q[x,y]}( J2 ) )
+#! ( V_{Q[x,y]}( I1 ) \ V_{Q[x,y]}( J1 ) ) ∪ ( V_{Q[x,y]}( I2 ) \ V_{Q[x,y]}( J2 ) )
 c0 := c - 0;
-#! ( V_{Q[x,y]}( I1 ) \ V_{Q[x,y]}( J1 ) ) + ( V_{Q[x,y]}( I2 ) \ V_{Q[x,y]}( J2 ) )
+#! ( V_{Q[x,y]}( I1 ) \ V_{Q[x,y]}( J1 ) ) ∪ ( V_{Q[x,y]}( I2 ) \ V_{Q[x,y]}( J2 ) )
 IsIdenticalObj( c, c0 );
 #! true
 c[1];

--- a/makedoc.g
+++ b/makedoc.g
@@ -10,7 +10,7 @@ fi;
 AutoDoc( 
         rec(
             scaffold := rec( gapdoc_latex_options := rec( 
-                             LateExtraPreamble := "\\usepackage{amsmath}\\usepackage[T1]{fontenc}\n\\usepackage{tikz}\n\\usetikzlibrary{shapes,arrows,matrix}\n\\usepackage{faktor}\n\\DeclareUnicodeCharacter{2205}{\\O}\n" 
+                             LateExtraPreamble := "\\usepackage{amsmath}\\usepackage[T1]{fontenc}\n\\usepackage{tikz}\n\\usetikzlibrary{shapes,arrows,matrix}\n\\usepackage{faktor}\n\\DeclareUnicodeCharacter{2205}{\\O}\n\\DeclareUnicodeCharacter{222A}{\\ensuremath{\\cup}}\n\\DeclareUnicodeCharacter{22C3}{\\ensuremath{\\bigcup}}\n" 
 
                                                         ),
                              entities := [ "GAP4", "CAP", "homalg" ],


### PR DESCRIPTION
- replace "+" by "∪" in examples/Example.g due commit 9d9d6cf in Locales

- add necessary \DeclareUnicodeCharacter commands to ensure that ∪ and ⋃ are correctly printed in the manual

This should be merged together with https://github.com/homalg-project/Locales/pull/3